### PR TITLE
Fix unexpected EOF

### DIFF
--- a/scripts/patterns.txt
+++ b/scripts/patterns.txt
@@ -114,7 +114,7 @@
 '$x || $_ || $_ || $_ || $x'
 
 # Duplicated array keys.
-'[${"*"}, $k => $_, ${"*"}, $k => $_, ${"*"}]
+'[${"*"}, $k => $_, ${"*"}, $k => $_, ${"*"}]'
 
 # Using "==" for string comparison (should use "===" instead).
 '${"s:str"} == $x' 's~^.\d'


### PR DESCRIPTION
../phpgrep/phpgrep-contrib/scripts/phpgrep-lint.sh: eval: line 48: unexpected EOF while looking for matching `''
../phpgrep/phpgrep-contrib/scripts/phpgrep-lint.sh: eval: line 49: syntax error: unexpected end of file
